### PR TITLE
Create responsive dashboard view

### DIFF
--- a/dashboard/dashboard.css
+++ b/dashboard/dashboard.css
@@ -1,0 +1,174 @@
+:root {
+    --dashboard-background: #10131a;
+    --dashboard-surface: rgba(17, 24, 39, 0.75);
+    --dashboard-border: #57A4FF;
+    --dashboard-text: #F6F6F6;
+    --dashboard-subtle: #B9B9B9;
+    --dashboard-accent: #57A4FF33;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html, body {
+    height: 100%;
+}
+
+body {
+    margin: 0;
+    font-family: "Lato", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: radial-gradient(circle at top right, rgba(87, 164, 255, 0.12), transparent 45%),
+                radial-gradient(circle at bottom left, rgba(87, 164, 255, 0.09), transparent 55%),
+                var(--dashboard-background);
+    color: var(--dashboard-text);
+    display: flex;
+    flex-direction: column;
+}
+
+.dashboard {
+    width: min(1100px, 100%);
+    margin: 0 auto;
+    padding: 56px 24px 72px;
+    display: flex;
+    flex-direction: column;
+    gap: 48px;
+}
+
+.dashboard__header {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.dashboard__title {
+    font-family: "Do Hyeon", sans-serif;
+    font-size: clamp(2rem, 3vw, 2.8rem);
+    letter-spacing: 4px;
+    text-transform: uppercase;
+}
+
+.dashboard__subtitle {
+    color: var(--dashboard-subtle);
+    font-size: 1rem;
+}
+
+.dashboard__section-title {
+    margin: 0 0 16px 0;
+    font-family: "Do Hyeon", sans-serif;
+    font-size: clamp(1.5rem, 2.3vw, 2rem);
+    letter-spacing: 3px;
+}
+
+.dashboard__kpi-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 24px;
+    justify-content: center;
+    justify-items: center;
+}
+
+.dashboard__kpi-card {
+    width: min(100%, 260px);
+    padding: 24px;
+    border-radius: 18px;
+    border: 2px solid var(--dashboard-border);
+    background: var(--dashboard-surface);
+    backdrop-filter: blur(6px);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    box-shadow: 0 18px 40px -24px rgba(0, 0, 0, 0.8);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.dashboard__kpi-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 24px 60px -30px rgba(16, 52, 100, 0.65);
+}
+
+.dashboard__kpi-label {
+    font-size: 0.85rem;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    color: var(--dashboard-subtle);
+}
+
+.dashboard__kpi-value {
+    font-family: "Do Hyeon", sans-serif;
+    font-size: clamp(2rem, 4vw, 2.8rem);
+    letter-spacing: 2px;
+}
+
+.dashboard__kpi-trend {
+    font-size: 0.9rem;
+    color: rgba(86, 214, 143, 0.9);
+}
+
+.dashboard__kpi-trend.is-negative {
+    color: #FF7A7A;
+}
+
+.dashboard__quick-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.dashboard__quick-actions-description {
+    color: var(--dashboard-subtle);
+    max-width: 540px;
+    font-size: 1rem;
+    line-height: 1.6;
+}
+
+.dashboard__quick-actions-wrapper {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    justify-content: flex-start;
+}
+
+.dashboard__quick-action-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 12px 22px;
+    border-radius: 12px;
+    border: 2px solid var(--dashboard-border);
+    color: var(--dashboard-text);
+    background: var(--dashboard-surface);
+    text-transform: uppercase;
+    font-weight: 600;
+    letter-spacing: 1.4px;
+    transition: background 0.25s ease, transform 0.25s ease;
+}
+
+.dashboard__quick-action-button:hover {
+    background: var(--dashboard-accent);
+    transform: translateY(-2px);
+}
+
+.dashboard__footer {
+    margin-top: auto;
+    padding: 32px 24px;
+    text-align: center;
+    color: var(--dashboard-subtle);
+    font-size: 0.9rem;
+}
+
+@media (max-width: 640px) {
+    .dashboard {
+        padding: 40px 18px 56px;
+        gap: 40px;
+    }
+
+    .dashboard__quick-actions-wrapper {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .dashboard__quick-action-button {
+        width: 100%;
+    }
+}

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dashboard - Indicadores</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Do+Hyeon&family=Lato:wght@300;400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../reset.css">
+    <link rel="stylesheet" href="dashboard.css">
+</head>
+<body>
+    <main class="dashboard">
+        <header class="dashboard__header">
+            <h1 class="dashboard__title">Painel de resultados</h1>
+            <p class="dashboard__subtitle">Acompanhe os principais indicadores operacionais da sua organização em tempo real.</p>
+        </header>
+
+        <section class="dashboard__kpis" aria-labelledby="titulo-kpis">
+            <h2 id="titulo-kpis" class="dashboard__section-title">KPIs</h2>
+            <div class="dashboard__kpi-grid">
+                <article class="dashboard__kpi-card">
+                    <span class="dashboard__kpi-label">Empresas ativas</span>
+                    <strong class="dashboard__kpi-value">128</strong>
+                    <span class="dashboard__kpi-trend">+5 este mês</span>
+                </article>
+                <article class="dashboard__kpi-card">
+                    <span class="dashboard__kpi-label">Novos acionistas</span>
+                    <strong class="dashboard__kpi-value">42</strong>
+                    <span class="dashboard__kpi-trend">+12% vs. mês anterior</span>
+                </article>
+                <article class="dashboard__kpi-card">
+                    <span class="dashboard__kpi-label">Atos registrados</span>
+                    <strong class="dashboard__kpi-value">311</strong>
+                    <span class="dashboard__kpi-trend">+34 na última semana</span>
+                </article>
+                <article class="dashboard__kpi-card">
+                    <span class="dashboard__kpi-label">Pendências</span>
+                    <strong class="dashboard__kpi-value">18</strong>
+                    <span class="dashboard__kpi-trend is-negative">-7% desde ontem</span>
+                </article>
+            </div>
+        </section>
+
+        <section class="dashboard__quick-actions" aria-labelledby="titulo-acoes">
+            <h2 id="titulo-acoes" class="dashboard__section-title">Ações rápidas</h2>
+            <p class="dashboard__quick-actions-description">Execute tarefas frequentes em apenas um clique. Todos os botões estão alinhados ao início para facilitar o acesso imediato.</p>
+            <div class="dashboard__quick-actions-wrapper">
+                <button type="button" class="dashboard__quick-action-button">Cadastrar empresa</button>
+                <button type="button" class="dashboard__quick-action-button">Novo acionista</button>
+                <button type="button" class="dashboard__quick-action-button">Registrar ato</button>
+                <button type="button" class="dashboard__quick-action-button">Emitir relatório</button>
+            </div>
+        </section>
+    </main>
+
+    <footer class="dashboard__footer">
+        © 2024 Lucas Fuzinaga — Painel administrativo
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated dashboard page with KPI cards laid out in a responsive grid so they center and wrap gracefully
- style the quick actions area so its buttons align to the start while remaining responsive across breakpoints

## Testing
- not run (static HTML/CSS changes)


------
https://chatgpt.com/codex/tasks/task_e_68d17fa3a7108326b9239a7a5c575f3c